### PR TITLE
Added C++11 support for ROS melodic

### DIFF
--- a/taurob_teleop_twist_joy/CMakeLists.txt
+++ b/taurob_teleop_twist_joy/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(taurob_teleop_twist_joy)
+add_definitions(-std=c++11)
 #set(CMAKE_BUILD_TYPE Debug)
 
 find_package(catkin REQUIRED COMPONENTS geometry_msgs roscpp roslaunch roslint sensor_msgs trajectory_msgs)

--- a/taurob_teleop_twist_joy/include/teleop_twist_joy/simple_inverse_kinematics.h
+++ b/taurob_teleop_twist_joy/include/teleop_twist_joy/simple_inverse_kinematics.h
@@ -70,8 +70,8 @@ namespace teleop_twist_joy
 
         private:
 
-            static const double ELEMENT_A_LENGTH = 551;
-            static const double ELEMENT_B_LENGTH = 435;
+            static constexpr double ELEMENT_A_LENGTH = 551;
+            static constexpr double ELEMENT_B_LENGTH = 435;
 
             /** Performs forward kinematics to obtain joint 2 coordinates */
             static End_effector_coordinates Get_joint_2_coordinates(ModArm_angles angles);


### PR DESCRIPTION
In ROS Melodic on Ubuntu 18.04 with GCC 7.4.0 following changes are needed.
Also tested with ROS Kinetic on Ubuntu 16.04 with GCC 5.4.0 